### PR TITLE
Fix timeout deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Silenced Object#timeout deprecation warnings under Ruby 2.3 by using Timeout.timeout instead.
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/bin/handler-pushover.rb
+++ b/bin/handler-pushover.rb
@@ -56,7 +56,7 @@ class Pushover < Sensu::Handler
 
     keys.each do |key|
       begin
-        timeout(5) do
+        Timeout.timeout(5) do
           params['user'] = key['userkey']
           params['token'] = key['token']
           req.set_form_data(params)


### PR DESCRIPTION
## Pull Request Checklist

Silences `Object#timeout is deprecated` warnings under Ruby 2.3.0. I have tested this change in my local environment.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Known Compatablity Issues

None.
