### PR TITLE
remove conditional on require_relative in gemspec

### DIFF
--- a/sensu-plugins-pushover.gemspec
+++ b/sensu-plugins-pushover.gemspec
@@ -2,12 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-pushover'
-else
-  require_relative 'lib/sensu-plugins-pushover'
-end
+require_relative 'lib/sensu-plugins-pushover'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes another instance of Ruby 1.9.3 support per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.

This change should have been included in #4 but was overlooked.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
